### PR TITLE
Tech/independent settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+## 2.2.0 (May 7, 2020)
+
+- Initial publishing on NPM as **@frk/vue-tags-input**.
+- Update README according the new package name.

--- a/README.md
+++ b/README.md
@@ -2,32 +2,42 @@
 
 A tags input component for VueJS with autocompletion, custom validation, templating and much more
 
-[Demo & Docs](http://www.vue-tags-input.com)
+:information_source: Forked from @johmun/vue-tags-input which seems no longer maintained.
+
+[Demo & Docs](http://www.vue-tags-input.com) (:warning: → @johmun/vue-tags-input)
 
 ## Features
 
-* No dependencies
-* Custom validation rules
-* Hooks: Before adding, Before deleting ...
-* Edit tags after creation
-* Fast setup
-* Works with Vuex
-* Small size: 34kb minified (css included) | gzipped 9kb
-* Autocompletion
-* Many customization options
-* Own templates
-* Delete tags on backspace
-* Add tags on paste
-* Examples & Docs
+- No dependencies
+- Custom validation rules
+- Hooks: Before adding, Before deleting ...
+- Edit tags after creation
+- Fast setup
+- Works with Vuex
+- Small size: 34kb minified (css included) | gzipped 9kb
+- Autocompletion
+- Many customization options
+- Own templates
+- Delete tags on backspace
+- Add tags on paste
+- Examples & Docs
 
 ## Install
 
 NPM
+
 ```
-npm install @johmun/vue-tags-input
+npm install --save @frk/vue-tags-input
 ```
 
-CDN
+Yarn
+
+```
+yarn add @frk/vue-tags-input
+```
+
+CDN (:warning: → @johmun/vue-tags-input)
+
 ```
 <script src="https://unpkg.com/@johmun/vue-tags-input/dist/vue-tags-input.js"></script>
 ```
@@ -48,7 +58,7 @@ CDN
 
 ```javascript
 <script>
-import VueTagsInput from '@johmun/vue-tags-input';
+import VueTagsInput from '@frk/vue-tags-input';
 
 export default {
   components: {
@@ -68,4 +78,4 @@ export default {
 
 [MIT](https://opensource.org/licenses/MIT)
 
-Copyright (c) 2019 Johannes Munari
+Copyright (c) 2020 ODHCOM

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@johmun/vue-tags-input",
+  "name": "@frk/vue-tags-input",
   "version": "2.1.0",
   "author": "Johannes Munari <johannesm@hotmail.de>",
   "license": "MIT",
@@ -16,7 +16,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/JohMun/vue-tags-input.git"
+    "url": "git@github.com:freelanceRepublik/vue-tags-input.git"
   },
   "main": "dist/vue-tags-input.js",
   "scripts": {
@@ -111,5 +111,11 @@
     "plugins": {
       "autoprefixer": {}
     }
+  },
+  "bugs": {
+    "url": "https://github.com/freelanceRepublik/vue-tags-input/issues"
+  },
+  "directories": {
+    "doc": "docs"
   }
 }


### PR DESCRIPTION
## Current status

- `package.json` needs to be updated to publish the package onto NPM.
- README refers to forked package.

## New status

- Package **@frk/vue-tags-input** can be published on NPM.